### PR TITLE
Handdle application error bugfix

### DIFF
--- a/src/middlewares/error-handling-middleware.ts
+++ b/src/middlewares/error-handling-middleware.ts
@@ -1,8 +1,13 @@
 import { ApplicationError } from "@/protocols";
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import httpStatus from "http-status";
 
-export function handleApplicationErrors(err: ApplicationError | Error, _req: Request, res: Response) {
+export function handleApplicationErrors(
+  err: ApplicationError | Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+  ) {
   if (err.name === "CannotEnrollBeforeStartDateError") {
     return res.status(httpStatus.BAD_REQUEST).send({
       message: err.message,
@@ -32,6 +37,11 @@ export function handleApplicationErrors(err: ApplicationError | Error, _req: Req
       message: err.message,
     });
   }
+
+  console.log("---------------------------")
+  console.log(res)
+  console.log("---------------------------")
+  // console.log(err)
 
   /* eslint-disable-next-line no-console */
   console.error(err.name);

--- a/src/middlewares/error-handling-middleware.ts
+++ b/src/middlewares/error-handling-middleware.ts
@@ -38,11 +38,6 @@ export function handleApplicationErrors(
     });
   }
 
-  console.log("---------------------------")
-  console.log(res)
-  console.log("---------------------------")
-  // console.log(err)
-
   /* eslint-disable-next-line no-console */
   console.error(err.name);
   res.status(httpStatus.INTERNAL_SERVER_ERROR).send({


### PR DESCRIPTION
Foi encontrado um pequeno erro que estava quebrando o middleware. O erro consistia em basicamente a função não receber o parâmetro NextFunction que o express injeta, isso fazia com que o parâmetro res:Response da função, recebesse o NextFunction no lugar do Response, impossibilitando as invocações de res.{...} dentro da função.